### PR TITLE
BASK54: Unit Tests for Searching Profiles #118

### DIFF
--- a/src/main/java/com/basilisk/backend/presenters/MenuBarPresenter.java
+++ b/src/main/java/com/basilisk/backend/presenters/MenuBarPresenter.java
@@ -33,7 +33,7 @@ public class MenuBarPresenter {
         return userService.retrieveAllUsers();
     }
 
-    public List<User> getSelectedUsers(String name) {
+    public List<User> searchByUsername(String name) {
         return userService.searchForUsers(name);
     }
 }

--- a/src/main/java/com/basilisk/frontend/components/MenuBarComponent.java
+++ b/src/main/java/com/basilisk/frontend/components/MenuBarComponent.java
@@ -49,7 +49,7 @@ public class MenuBarComponent extends PolymerTemplate<MenuBarComponent.MenuBarCo
 
         //Listener for when user presses enter on combo box
         searchComboBox.addCustomValueSetListener(event -> {
-            List<User> searchedUsers = menuBarPresenter.getSelectedUsers(event.getDetail());
+            List<User> searchedUsers = menuBarPresenter.searchByUsername(event.getDetail());
             searchedUsers.sort(new UserCompare());
             User user = searchedUsers.get(0);
             UI.getCurrent().navigate(Constants.PROFILE_ROUTE + user.getUsername());

--- a/src/test/java/com/basilisk/CrudTests.java
+++ b/src/test/java/com/basilisk/CrudTests.java
@@ -193,7 +193,7 @@ public class CrudTests extends Tests {
         try {
             deletedTweet = tweetRepository.getOne(tweet.getId());
         } catch (JpaObjectRetrievalFailureException e) {
-            e.printStackTrace();
+            //e.printStackTrace();
         }
 
         // Verify the retrieved deleted tweet from the repository is not there (null)

--- a/src/test/java/com/basilisk/SearchTests.java
+++ b/src/test/java/com/basilisk/SearchTests.java
@@ -42,8 +42,6 @@ public class SearchTests extends Tests {
         assertNotNull(allUsers);
 
         assertTrue(allUsers.contains(testUser));
-
-        userService.removeUser(testUser);
     }
 
     @Test
@@ -63,8 +61,6 @@ public class SearchTests extends Tests {
 
         // testUser won't be in the list otherwise
         assertFalse(menuBarPresenter.searchByUsername("asdfghjkl").contains(testUser));
-
-        userService.removeUser(testUser);
     }
 
 }

--- a/src/test/java/com/basilisk/SearchTests.java
+++ b/src/test/java/com/basilisk/SearchTests.java
@@ -1,0 +1,70 @@
+package com.basilisk;
+
+import com.basilisk.backend.models.User;
+import com.basilisk.backend.presenters.MenuBarPresenter;
+import com.basilisk.backend.services.UserService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+public class SearchTests extends Tests {
+
+    @Autowired
+    private MenuBarPresenter menuBarPresenter;
+
+    @Autowired
+    private UserService userService;
+
+    @BeforeAll
+    public static void setUp() {
+
+    }
+
+    @Test
+    public void GetAllUsersTest() {
+        User testUser = new User("TestUser", "testUser", "password", "", null);
+
+        /* New user created to test if menuBarPresenter.getAllUsers()
+        returns a list containing that user */
+        userService.createNewUser(testUser);
+
+        assertDoesNotThrow(() -> {
+            List<User> allUsers = menuBarPresenter.getAllUsers();
+        });
+        List<User> allUsers = menuBarPresenter.getAllUsers();
+
+        assertNotNull(allUsers);
+
+        assertTrue(allUsers.contains(testUser));
+
+        userService.removeUser(testUser);
+    }
+
+    @Test
+    public void searchByUsernameTest() {
+        User testUser = new User("TestUser", "qwertyuiop", "password", "", null);
+
+        /* Created user has a specific username to test if menuBarPresenter.searchByUsername()
+        returns a list containing that user */
+        userService.createNewUser(testUser);
+
+        assertDoesNotThrow(() -> {
+            List<User> allUsers = menuBarPresenter.searchByUsername("asdf");
+        });
+        // testUser must be in the list if its username contains the search term
+        assertTrue(menuBarPresenter.searchByUsername("qwertyuiop").contains(testUser));
+        assertTrue(menuBarPresenter.searchByUsername("ertyui").contains(testUser));
+
+        // testUser won't be in the list otherwise
+        assertFalse(menuBarPresenter.searchByUsername("asdfghjkl").contains(testUser));
+
+        userService.removeUser(testUser);
+    }
+
+}


### PR DESCRIPTION
BASK54 (Issue #118): Added Search unit tests
   - Renamed MenuBarPresenter method
   - Added unit tests for method getAllUsers from MenuBarPresenter
   - Added unit tests for method searchByUsername from MenuBarPresenter
   - Commented out printStackTrace from CrudTests