### PR TITLE
BASK56: Trimming the Inputs for Tweets and Comments

### DIFF
--- a/src/main/java/com/basilisk/Constants.java
+++ b/src/main/java/com/basilisk/Constants.java
@@ -1,8 +1,21 @@
 package com.basilisk;
 
-public interface Constants {
-    String CURRENT_USER = "currentUser";
-    String USER_PROFILE = "userProfile";
-    String PROFILE_ROUTE = "profile/";
-    String HOME_ROUTE = "home/";
+public abstract class Constants {
+    public static final String CURRENT_USER = "currentUser";
+    public static final String USER_PROFILE = "userProfile";
+    public static final String PROFILE_ROUTE = "profile/";
+    public static final String HOME_ROUTE = "home/";
+
+    /**
+     * Sanitizes strings by trimming whitespace off the ends and removing unnecessary newlines
+     *
+     * @return Sanitized string
+     */
+    public static String cleanString(String input) {
+        input = input.trim();
+        input = input.replaceAll("\\n{3,}", "\n\n");
+        input = input.replaceAll("\\r{3,}", "\r\r");
+        input = input.replaceAll("(\\r\\n){3,}", "\r\n\r\n");
+        return input;
+    }
 }

--- a/src/main/java/com/basilisk/backend/presenters/HomePresenter.java
+++ b/src/main/java/com/basilisk/backend/presenters/HomePresenter.java
@@ -27,7 +27,7 @@ public class HomePresenter {
 
     @Autowired
     public HomePresenter(UserService userService, TweetService tweetService, RetweetService retweetService,
-                         FollowService followService, CommentService commentService, TweetPresenter tweetPresenter){
+                         FollowService followService, CommentService commentService, TweetPresenter tweetPresenter) {
         this.userService = userService;
         this.tweetService = tweetService;
         this.retweetService = retweetService;

--- a/src/main/java/com/basilisk/backend/presenters/LoginPresenter.java
+++ b/src/main/java/com/basilisk/backend/presenters/LoginPresenter.java
@@ -23,7 +23,7 @@ public class LoginPresenter {
 
     @Autowired
     public LoginPresenter(UserService userService, TweetService tweetService, RetweetService retweetService,
-                          FollowService followService, CommentService commentService){
+                          FollowService followService, CommentService commentService) {
         this.userService = userService;
         this.tweetService = tweetService;
         this.retweetService = retweetService;

--- a/src/main/java/com/basilisk/backend/presenters/MenuBarPresenter.java
+++ b/src/main/java/com/basilisk/backend/presenters/MenuBarPresenter.java
@@ -21,7 +21,7 @@ public class MenuBarPresenter {
 
     @Autowired
     public MenuBarPresenter(UserService userService, TweetService tweetService, RetweetService retweetService,
-                            FollowService followService, CommentService commentService){
+                            FollowService followService, CommentService commentService) {
         this.userService = userService;
         this.userService = userService;
         this.tweetService = tweetService;

--- a/src/main/java/com/basilisk/backend/presenters/ProfilePresenter.java
+++ b/src/main/java/com/basilisk/backend/presenters/ProfilePresenter.java
@@ -34,7 +34,7 @@ public class ProfilePresenter {
 
     @Autowired
     public ProfilePresenter(UserService userService, TweetService tweetService, RetweetService retweetService,
-                            TweetPresenter tweetPresenter, FollowService followService, CommentService commentService){
+                            TweetPresenter tweetPresenter, FollowService followService, CommentService commentService) {
         this.userService = userService;
         this.tweetService = tweetService;
         this.retweetService = retweetService; //Added this 2019-03-04 12:00 PM

--- a/src/main/java/com/basilisk/backend/presenters/TweetPresenter.java
+++ b/src/main/java/com/basilisk/backend/presenters/TweetPresenter.java
@@ -2,6 +2,7 @@
 
 package com.basilisk.backend.presenters;
 
+import com.basilisk.Constants;
 import com.basilisk.backend.models.Comment;
 import com.basilisk.backend.models.Retweet;
 import com.basilisk.backend.models.Tweet;
@@ -26,7 +27,7 @@ public class TweetPresenter {
     private static Logger LOGGER = Logger.getLogger(ProfilePresenter.class);
 
     public TweetPresenter(UserService userService, TweetService tweetService, FollowService followService,
-                          RetweetService retweetService, CommentService commentService){
+                          RetweetService retweetService, CommentService commentService) {
         this.followService = followService;
         this.userService = userService;
         this.tweetService = tweetService;
@@ -36,6 +37,7 @@ public class TweetPresenter {
 
     public boolean createAndSaveTweet(String tweetText, User currentUser) {
         if (!tweetText.isEmpty()) {
+            tweetText = Constants.cleanString(tweetText);
             Tweet tweet = new Tweet(tweetText, currentUser);
             LOGGER.info("Tweet creation success: " + tweetText);
             tweetService.writeTweet(tweet);
@@ -46,16 +48,15 @@ public class TweetPresenter {
         }
     }
 
-    public boolean createAndSaveComment(String commentText, Tweet tweet, User currentUser)
-    {
+    public boolean createAndSaveComment(String commentText, Tweet tweet, User currentUser) {
         if (!commentText.isEmpty()) {
+            commentText = Constants.cleanString(commentText);
             Comment comment = new Comment(commentText, currentUser, tweet);
             LOGGER.info("Comment creation success: " + commentText);
             LOGGER.info("Comment: " + comment.getText() + comment.getUser().toString() + comment.getTweet().toString());
             commentService.writeComment(comment);
             return true;
-        } else
-        {
+        } else {
             LOGGER.info("Comment creation failure " + commentText);
             return false;
         }
@@ -89,8 +90,7 @@ public class TweetPresenter {
         return true;
     }
 
-    public List<Comment> getTweetComments(Tweet tweet)
-    {
+    public List<Comment> getTweetComments(Tweet tweet) {
         return commentService.getTweetComments(tweet);
     }
 

--- a/src/main/java/com/basilisk/backend/services/CommentService.java
+++ b/src/main/java/com/basilisk/backend/services/CommentService.java
@@ -20,18 +20,15 @@ public class CommentService {
     }
 
     // Public Service methods
-    public void writeComment(Comment comment)
-    {
+    public void writeComment(Comment comment) {
         createComment(comment);
     }
 
-    public void editComment(Comment comment)
-    {
+    public void editComment(Comment comment) {
         updateComment(comment);
     }
 
-    public Comment getCommentById(long id)
-    {
+    public Comment getCommentById(long id) {
         return retrieveComment(id);
     }
 

--- a/src/main/java/com/basilisk/backend/services/FollowService.java
+++ b/src/main/java/com/basilisk/backend/services/FollowService.java
@@ -22,20 +22,20 @@ public class FollowService {
     // Public Service methods
 
     // Returns the followings of a user.
-    public List<User> getAllUserFollowings(User user){
+    public List<User> getAllUserFollowings(User user) {
         return followRepository.getAllByFollower(user).stream().map(Follow::getFollowed).collect(Collectors.toList());
     }
 
     // Returns the followers of a user.
-    public List<User> getAllUserFollowers(User user){
+    public List<User> getAllUserFollowers(User user) {
         return followRepository.getAllByFollowed(user).stream().map(Follow::getFollower).collect(Collectors.toList());
     }
 
-    public void follow(User follower, User followed){
+    public void follow(User follower, User followed) {
         createFollow(new Follow(follower, followed));
     }
 
-    public void unfollow(User follower, User followed){
+    public void unfollow(User follower, User followed) {
         deleteFollow(retrieveFollowByFollowerAndFollowed(follower, followed));
     }
 

--- a/src/main/java/com/basilisk/backend/services/RetweetService.java
+++ b/src/main/java/com/basilisk/backend/services/RetweetService.java
@@ -21,15 +21,25 @@ public class RetweetService {
     }
 
     // Public Service methods
-    public void postRetweet(Retweet retweet) { createRetweet(retweet); }
+    public void postRetweet(Retweet retweet) {
+        createRetweet(retweet);
+    }
 
-    public void removeRetweet(Retweet retweet) { deleteRetweet(retweet); }
+    public void removeRetweet(Retweet retweet) {
+        deleteRetweet(retweet);
+    }
 
-    public Retweet getRetweetById(long id) { return retrieveRetweet(id); }
+    public Retweet getRetweetById(long id) {
+        return retrieveRetweet(id);
+    }
 
-    public List<Retweet> getAllRetweetsByUser(User user) { return retrieveAllRetweets(user); }
+    public List<Retweet> getAllRetweetsByUser(User user) {
+        return retrieveAllRetweets(user);
+    }
 
-    public List<Retweet> getAllRetweetsByTweet(Tweet tweet) { return retrieveAllRetweetsByTweet(tweet); }
+    public List<Retweet> getAllRetweetsByTweet(Tweet tweet) {
+        return retrieveAllRetweetsByTweet(tweet);
+    }
 
     // private CRUD Operations
     private void createRetweet(Retweet retweet) {
@@ -48,8 +58,12 @@ public class RetweetService {
         return retweetRepository.getOne(id);
     }
 
-    private List<Retweet> retrieveAllRetweets(User user) { return retweetRepository.getAllByUser(user); }
+    private List<Retweet> retrieveAllRetweets(User user) {
+        return retweetRepository.getAllByUser(user);
+    }
 
-    private List<Retweet> retrieveAllRetweetsByTweet(Tweet tweet) { return retweetRepository.getAllByTweet(tweet); }
+    private List<Retweet> retrieveAllRetweetsByTweet(Tweet tweet) {
+        return retweetRepository.getAllByTweet(tweet);
+    }
 
 }

--- a/src/main/java/com/basilisk/backend/services/TweetService.java
+++ b/src/main/java/com/basilisk/backend/services/TweetService.java
@@ -28,13 +28,17 @@ public class TweetService {
         updateTweet(tweet);
     }
 
-    public void removeTweet(Tweet tweet) { deleteTweet(tweet); }
+    public void removeTweet(Tweet tweet) {
+        deleteTweet(tweet);
+    }
 
     public Tweet getTweetById(long id) {
         return retrieveTweet(id);
     }
 
-    public List<Tweet> getAllTweetsByUser(User user) { return retrieveAllTweets(user); }
+    public List<Tweet> getAllTweetsByUser(User user) {
+        return retrieveAllTweets(user);
+    }
 
     //CRUD OPERATIONS
     private void createTweet(Tweet tweet) {
@@ -53,5 +57,7 @@ public class TweetService {
         return tweetRepository.getOne(id);
     }
 
-    private List<Tweet> retrieveAllTweets(User user) { return tweetRepository.getAllByUser(user); }
+    private List<Tweet> retrieveAllTweets(User user) {
+        return tweetRepository.getAllByUser(user);
+    }
 }

--- a/src/main/java/com/basilisk/frontend/components/TweetCreateComponent.java
+++ b/src/main/java/com/basilisk/frontend/components/TweetCreateComponent.java
@@ -18,7 +18,7 @@ import com.vaadin.flow.templatemodel.TemplateModel;
 @HtmlImport("tweet-create-component.html")
 public class TweetCreateComponent extends PolymerTemplate<TweetCreateComponent.TweetCreateComponentModel> {
 
-    private static final int TWEET_MAX_LENGTH = 280;
+    private static final int TWEET_MAX_LENGTH = 250;
 
     @Id("createButton")
     private Button likeButton;

--- a/src/main/java/com/basilisk/frontend/components/TweetCreateComponent.java
+++ b/src/main/java/com/basilisk/frontend/components/TweetCreateComponent.java
@@ -18,6 +18,8 @@ import com.vaadin.flow.templatemodel.TemplateModel;
 @HtmlImport("tweet-create-component.html")
 public class TweetCreateComponent extends PolymerTemplate<TweetCreateComponent.TweetCreateComponentModel> {
 
+    private static final int TWEET_MAX_LENGTH = 280;
+
     @Id("createButton")
     private Button likeButton;
     @Id("tweetMessage")
@@ -28,6 +30,7 @@ public class TweetCreateComponent extends PolymerTemplate<TweetCreateComponent.T
     public TweetCreateComponent(TweetPresenter tweetPresenter) {
         // You can initialise any data required for the connected UI components here.
         this.tweetPresenter = tweetPresenter;
+        tweetMessage.setMaxLength(TWEET_MAX_LENGTH);
     }
 
     @EventHandler

--- a/src/main/java/com/basilisk/frontend/components/TweetDisplayComponent.java
+++ b/src/main/java/com/basilisk/frontend/components/TweetDisplayComponent.java
@@ -110,8 +110,7 @@ public class TweetDisplayComponent extends PolymerTemplate<TweetDisplayComponent
             retweetLabel.setValue("Retweeted by " + retweetedBy.getUsername());
             if (!currentUser.equals(retweetedBy))
                 deleteButton.setVisible(false);
-        }
-        else {
+        } else {
             retweetLabel.setVisible(false);
             if (!currentUser.equals(tweet.getUser()))
                 deleteButton.setVisible(false);
@@ -141,9 +140,7 @@ public class TweetDisplayComponent extends PolymerTemplate<TweetDisplayComponent
         if (tweetComments.size() > 0) {
             showComments.setText(SHOW + " (" + tweetComments.size() + ")");
             hideComments.setVisible(false);
-        }
-        else
-        {
+        } else {
             showComments.setVisible(false);
             hideComments.setVisible(false);
         }
@@ -205,7 +202,7 @@ public class TweetDisplayComponent extends PolymerTemplate<TweetDisplayComponent
         List<Comment> tweetComments = tweetPresenter.getTweetComments(tweet);
         isCommentHidden = false;
         isCommentShown = true;
-        for (;numberOfShownComments < tweetComments.size() && numberOfShownComments < 5 * showCommentsClickedCounter; ++numberOfShownComments) {
+        for (; numberOfShownComments < tweetComments.size() && numberOfShownComments < 5 * showCommentsClickedCounter; ++numberOfShownComments) {
             CommentDisplayComponent wComment = new CommentDisplayComponent(tweetComments.get(numberOfShownComments));
             commentDisplay.add(wComment);
         }
@@ -217,8 +214,7 @@ public class TweetDisplayComponent extends PolymerTemplate<TweetDisplayComponent
 
         if (tweetComments.size() - numberOfShownComments <= 0) {
             showComments.setVisible(false);
-        }
-        else {
+        } else {
             showComments.setText(SHOW + " (" + (tweetComments.size() - numberOfShownComments) + ")");
             ++showCommentsClickedCounter;
         }
@@ -227,7 +223,7 @@ public class TweetDisplayComponent extends PolymerTemplate<TweetDisplayComponent
     @EventHandler
     private void hideCommentsClicked() {
         List<Comment> tweetComments = tweetPresenter.getTweetComments(tweet);
-        if (numberOfShownComments  > 0) {
+        if (numberOfShownComments > 0) {
             if (isCommentShown == true) {
                 isCommentHidden = true;
                 isCommentShown = false;
@@ -241,9 +237,7 @@ public class TweetDisplayComponent extends PolymerTemplate<TweetDisplayComponent
                 showComments.setVisible(true);
                 showComments.setText(SHOW + " (" + (tweetComments.size() - numberOfShownComments) + ")");
             }
-        }
-        else
-        {
+        } else {
             hideComments.setVisible(false);
         }
     }
@@ -263,8 +257,7 @@ public class TweetDisplayComponent extends PolymerTemplate<TweetDisplayComponent
         if (isRetweet) {
             if (currentUser.equals(retweetedBy))
                 tweetPresenter.deleteRetweet(retweet);
-        }
-        else {
+        } else {
             if (currentUser.equals(tweet.getUser()))
                 tweetPresenter.deleteTweet(tweet);
         }

--- a/src/main/java/com/basilisk/frontend/views/ProfileView.java
+++ b/src/main/java/com/basilisk/frontend/views/ProfileView.java
@@ -207,8 +207,10 @@ public class ProfileView extends PolymerTemplate<ProfileView.ProfileViewModel> i
         } else {
             //Save Mode
             editButton.setText("Edit");
+            String bio = Constants.cleanString(userBioTextArea.getValue());
+            userBioTextArea.setValue(bio);
             userBioTextArea.setReadOnly(true);
-            currentUser.setBiography(userBioTextArea.getValue());
+            currentUser.setBiography(bio);
             profilePresenter.saveBiography(currentUser);
 
         }


### PR DESCRIPTION
BASK56 (Issue #120): Trimming the Inputs for Tweets and Comments
   - Added string white space cleanup method
   - Using the method for the creation of tweets, comments and for changes to the bio
   - set the character limit for tweets to 250